### PR TITLE
feat: Install usg package during the installation phase

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ops ~= 2.5
+charmhelpers ~= 1.2

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,16 +13,17 @@ https://juju.is/docs/sdk/create-a-minimal-kubernetes-charm
 """
 
 import logging
-from typing import cast
 import tempfile
 import base64
 import subprocess
 import ops
+import charmhelpers.fetch as fetch
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
 
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
+USG_PACKAGE = "usg"
 
 
 class CharmCisHardeningCharm(ops.CharmBase):
@@ -36,21 +37,32 @@ class CharmCisHardeningCharm(ops.CharmBase):
         framework.observe(self.on.execute_audit_action, self._on_audit_action)
 
     def _on_install(self, event):
+        self.install_usg()
         self.unit.status = ops.ActiveStatus("Ready to execute CIS hardening.")
         if self.model.config["auto-harden"]:
             self.cis_harden()
 
     def _on_audit_action(self, event):
         self.audit("/tmp/audit.results")
-            
+
     def audit(self, results_file):
-        return subprocess.check_output(f"usg audit --tailoring-file {results_file}".split(" ")).decode('utf-8')
+        return subprocess.check_output(
+            f"usg audit --tailoring-file {results_file}".split(" ")
+        ).decode("utf-8")
+
+    def install_usg(self):
+        pkg = USG_PACKAGE
+        self.unit.status = ops.MaintenanceStatus(f"Installing {pkg}")
+        fetch.apt_install([pkg], fatal=True)
+        self.unit.status = ops.ActiveStatus("Ready to execute CIS hardening")
 
     def cis_harden(self):
         with tempfile.NamedTemporaryFile("w", delete=False) as fh:
-            fh.write(base64.b64decode(self.model.config["tailoring-file"]).decode('utf-8'))
+            fh.write(base64.b64decode(self.model.config["tailoring-file"]).decode("utf-8"))
             fh.flush()
-            return subprocess.check_output(f"usg fix --tailoring-file {fh.name}".split(" ")).decode('utf-8')
+            return subprocess.check_output(
+                f"usg fix --tailoring-file {fh.name}".split(" ")
+            ).decode("utf-8")
 
     def _cis_harden_action(self, event):
         self.unit.status = ops.ActiveStatus("Executing hardening...")

--- a/src/charm.py
+++ b/src/charm.py
@@ -54,7 +54,6 @@ class CharmCisHardeningCharm(ops.CharmBase):
         pkg = USG_PACKAGE
         self.unit.status = ops.MaintenanceStatus(f"Installing {pkg}")
         fetch.apt_install([pkg], fatal=True)
-        self.unit.status = ops.ActiveStatus("Ready to execute CIS hardening")
 
     def cis_harden(self):
         with tempfile.NamedTemporaryFile("w", delete=False) as fh:


### PR DESCRIPTION
`usg` package is not installed by default.
Would be nice to install this package automatically before executing any `usg` command

FYI I'm using the [ubuntu-advantage](https://charmhub.io/ubuntu-advantage) charm, which doesn't install `usg` automatically. Maybe the installation of `usg` package should be moved into ubuntu-advantage charm instead 🤔

\+ remove unused package `typing`
\+ fix consistent formating quotes vs double-quotes in decode function
\+ split long commands in multiple lines (pylint format)