### PR TITLE
feat: Add pre-hardening-script configuration

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -53,6 +53,11 @@ config:
         The XML file in base64 to apply to the application.
       type: string
       default: ""
+    pre-hardening-script:
+      description: |
+        A Bash script to execute before the hardening
+      type: string
+      default: ""
 
 actions:
   execute-cis:


### PR DESCRIPTION
\+ Add pre-hardening-script configuration
This config will execute the content of `pre-hardening-script` configuration (if set) as a bash script.
\+ Error handling and blocked states
\+ Log errors and debug messages
\+ Handle case where `pre-hardening-script` is not set or leading to an error
\+ Handle case where `tailoring-file` is not set