### PR TITLE
Lots of changes, see comments :)

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -53,6 +53,11 @@ config:
         The XML file in base64 to apply to the application.
       type: string
       default: ""
+    pre-hardening-script:
+      description: |
+        A Bash script to execute before the hardening
+      type: string
+      default: ""
 
 actions:
   execute-cis:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,8 +8,8 @@ summary: A charm to perform CIS hardening with usg on the machine it runs on.
 description: |
   A charm to enable per-application CIS hardening
 links:
-  contact: https://launchpad.net/~pjds
-  documentation: https://discourse.charmhub.io/t/keystone-k8s-auth/14554
+  contact: https://launchpad.net/~fe-team
+  documentation: https://charmhub.io/charm-cis-hardening
   issues:
   - https://github.com/VariableDeclared/charm-cis-harden/issues
   source:

--- a/src/charm.py
+++ b/src/charm.py
@@ -44,7 +44,7 @@ class CharmCisHardeningCharm(ops.CharmBase):
         try:
             self.unit.status = ops.MaintenanceStatus("Installing dependencies...")
             self.install_usg()
-            self.unit.status = ops.BlockedStatus("Ready for CIS hardening. Run 'execute-cis' action")
+            self.unit.status = ops.ActiveStatus("Ready for CIS hardening. Run 'execute-cis' action")
 
             if self.model.config["auto-harden"]:
                 self.unit.status = ops.MaintenanceStatus("Auto-hardening enabled, starting hardening...")
@@ -61,7 +61,7 @@ class CharmCisHardeningCharm(ops.CharmBase):
             logger.error("Tailoring-file is not set")
             self.unit.status = ops.BlockedStatus("Cannot run hardening. Please configure a tailoring-file")
         else:
-            self.unit.status = ops.BlockedStatus("Ready for CIS hardening. Run 'execute-cis' action")
+            self.unit.status = ops.ActiveStatus("Ready for CIS hardening. Run 'execute-cis' action")
 
     def _on_start(self, event):
         # Workaround needed https://chat.canonical.com/canonical/pl/rr9su5ceh3r98r5jbiuu6989wr

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python3
 # Copyright 2024 pjds
 # See LICENSE file for licensing details.
-#
-# Learn more at: https://juju.is/docs/sdk
 
 """Charm CIS Hardening
 
-Refer to the following tutorial that will help you
-develop a new k8s charm using the Operator Framework:
-
-https://juju.is/docs/sdk/create-a-minimal-kubernetes-charm
+This charm implements CIS (Center for Internet Security) hardening for Juju units.
+It provides capabilities to install, configure, and audit security configurations
+based on CIS benchmarks.
 """
 
 import logging
@@ -24,53 +21,109 @@ logger = logging.getLogger(__name__)
 
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 USG_PACKAGE = "usg"
+AUDIT_RESULTS_PATH = "/tmp/audit.results"
 
 
 class CharmCisHardeningCharm(ops.CharmBase):
-    """Charm the service."""
+    """A charm for implementing CIS hardening standards on units."""
+
+    _stored = ops.framework.StoredState()
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
-        # framework.observe(self.on.config_changed, self._on_config_changed)
+        self._stored.set_default(hardening_status=False)
+
         framework.observe(self.on.execute_cis_action, self._cis_harden_action)
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.execute_audit_action, self._on_audit_action)
+        framework.observe(self.on.start, self._on_start)
 
     def _on_install(self, event):
-        self.install_usg()
-        self.unit.status = ops.ActiveStatus("Ready to execute CIS hardening.")
-        if self.model.config["auto-harden"]:
-            self.cis_harden()
+        try:
+            self.unit.status = ops.MaintenanceStatus("Installing dependencies...")
+            self.install_usg()
+
+            self.unit.status = ops.BlockedStatus("Ready for CIS hardening. Run 'execute-cis' action")
+
+            if self.model.config["auto-harden"]:
+                self.unit.status = ops.MaintenanceStatus("Auto-hardening enabled, starting hardening...")
+                self.cis_harden()
+        except Exception as e:
+            logger.error(f"Installation failed: {str(e)}")
+            self.unit.status = ops.BlockedStatus(f"Install failed: {str(e)}")
+
+    def _on_start(self, event):
+        if self._stored.hardening_status:
+            self.unit.status = ops.ActiveStatus("Unit is hardened. Use 'execute-audit' action to check compliance")
+        else:
+            self.unit.status = ops.BlockedStatus("Ready for CIS hardening. Run 'execute-cis' action")
 
     def _on_audit_action(self, event):
-        self.audit("/tmp/audit.results")
+        try:
+            results = self.audit(AUDIT_RESULTS_PATH)
+            event.set_results({
+                "result": results,
+                "file": AUDIT_RESULTS_PATH
+            })
+        except Exception as e:
+            logger.error(f"Audit failed: {str(e)}")
+            event.fail(f"Audit failed: {str(e)}")
 
     def audit(self, results_file):
-        return subprocess.check_output(
-            f"usg audit --tailoring-file {results_file}".split(" ")
-        ).decode("utf-8")
+        try:
+            return subprocess.check_output(
+                f"usg audit --tailoring-file {results_file}".split(" ")
+            ).decode("utf-8")
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Audit failed: {str(e)}")
+            raise
 
     def install_usg(self):
-        pkg = USG_PACKAGE
-        self.unit.status = ops.MaintenanceStatus(f"Installing {pkg}")
-        fetch.apt_install([pkg], fatal=True)
+        try:
+            fetch.apt_update()
+            fetch.apt_install([USG_PACKAGE], fatal=True)
+        except Exception as e:
+            logger.error(f"Failed to install {USG_PACKAGE}: {str(e)}")
+            raise
 
     def cis_harden(self):
-        with tempfile.NamedTemporaryFile("w", delete=False) as fh:
-            fh.write(base64.b64decode(self.model.config["tailoring-file"]).decode("utf-8"))
-            fh.flush()
-            return subprocess.check_output(
-                f"usg fix --tailoring-file {fh.name}".split(" ")
-            ).decode("utf-8")
+        try:
+            with tempfile.NamedTemporaryFile(mode="w", delete=False) as fh:
+                tailoring_content = base64.b64decode(
+                    self.model.config["tailoring-file"]
+                ).decode("utf-8")
+                fh.write(tailoring_content)
+                fh.flush()
+                cmd = ["usg", "fix", "--tailoring-file", fh.name]
+                return subprocess.check_output(cmd, text=True)
+        except Exception as e:
+            logger.error(f"Hardening failed: {str(e)}")
+            raise
 
     def _cis_harden_action(self, event):
         self.unit.status = ops.MaintenanceStatus("Executing hardening...")
-        output = self.cis_harden()
-        with tempfile.NamedTemporaryFile("w", delete=False) as fh:
-            fh.write(output)
-            event.set_results({"Result": "Complete!", "Results file": fh.name})
-        self.unit.status = ops.ActiveStatus("Hardening complete.")
+        self._stored.hardening_status = False
+
+        try:
+            output = self.cis_harden()
+            filename = None
+            with tempfile.NamedTemporaryFile(mode="w", delete=False) as fh:
+                fh.write(output)
+                filename = fh.name
+            event.set_results({
+                "result": "Complete! Please reboot the unit",
+                "file": filename
+            })
+            self.unit.status = ops.BlockedStatus(
+                f"Hardening complete. Results in {filename}. Please reboot the unit"
+            )
+            self._stored.hardening_status = True
+
+        except Exception as e:
+            logger.error(f"Hardening action failed: {str(e)}")
+            event.fail(f"Hardening failed: {str(e)}")
+            self.unit.status = ops.BlockedStatus("Hardening failed. Check juju debug-log")
 
 
-if __name__ == "__main__":  # pragma: nocover
-    ops.main(CharmCisHardeningCharm)  # type: ignore
+if __name__ == "__main__":
+    ops.main(CharmCisHardeningCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -53,6 +53,10 @@ class CharmCisHardeningCharm(ops.CharmBase):
             self.unit.status = ops.BlockedStatus(f"Install failed: {str(e)}")
 
     def _on_start(self, event):
+        # Workaround needed https://chat.canonical.com/canonical/pl/rr9su5ceh3r98r5jbiuu6989wr
+        subprocess.check_output(
+            "sysctl --system".split(" ")
+        ).decode("utf-8")
         if self._stored.hardening_status:
             self.unit.status = ops.ActiveStatus("Unit is hardened. Use 'execute-audit' action to check compliance")
         else:

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 USG_PACKAGE = "usg"
-AUDIT_RESULTS_PATH = "/tmp/audit.results"
+AUDIT_HTML_RESULTS_PATH = "/tmp/audit.results.html"
+AUDIT_XML_RESULTS_PATH = "/tmp/audit.results.xml"
 
 
 class CharmCisHardeningCharm(ops.CharmBase):
@@ -33,6 +34,7 @@ class CharmCisHardeningCharm(ops.CharmBase):
         super().__init__(framework)
         self._stored.set_default(hardening_status=False)
 
+        framework.observe(self.on.config_changed, self._on_config_changed)
         framework.observe(self.on.execute_cis_action, self._cis_harden_action)
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.execute_audit_action, self._on_audit_action)
@@ -42,7 +44,6 @@ class CharmCisHardeningCharm(ops.CharmBase):
         try:
             self.unit.status = ops.MaintenanceStatus("Installing dependencies...")
             self.install_usg()
-
             self.unit.status = ops.BlockedStatus("Ready for CIS hardening. Run 'execute-cis' action")
 
             if self.model.config["auto-harden"]:
@@ -52,32 +53,59 @@ class CharmCisHardeningCharm(ops.CharmBase):
             logger.error(f"Installation failed: {str(e)}")
             self.unit.status = ops.BlockedStatus(f"Install failed: {str(e)}")
 
+    def check_state(self):
+        if self._stored.hardening_status:
+            self.unit.status = ops.ActiveStatus("Unit is hardened. Use 'execute-audit' action to check compliance")
+            return
+        if not self.is_configuration_set("tailoring-file"):
+            logger.error("Tailoring-file is not set")
+            self.unit.status = ops.BlockedStatus("Cannot run hardening. Please configure a tailoring-file")
+        else:
+            self.unit.status = ops.BlockedStatus("Ready for CIS hardening. Run 'execute-cis' action")
+
     def _on_start(self, event):
         # Workaround needed https://chat.canonical.com/canonical/pl/rr9su5ceh3r98r5jbiuu6989wr
         subprocess.check_output(
             "sysctl --system".split(" ")
         ).decode("utf-8")
-        if self._stored.hardening_status:
-            self.unit.status = ops.ActiveStatus("Unit is hardened. Use 'execute-audit' action to check compliance")
-        else:
-            self.unit.status = ops.BlockedStatus("Ready for CIS hardening. Run 'execute-cis' action")
+        self.check_state()
+
+    def _on_config_changed(self, event):
+        self.check_state()
 
     def _on_audit_action(self, event):
+        if not self.is_configuration_set("tailoring-file"):
+            logger.error("Tailoring-file is not set")
+            event.fail("Tailoring-file is not set")
+            self.unit.status = ops.BlockedStatus("Cannot run hardening. Please configure a tailoring-file")
+            return
         try:
-            results = self.audit(AUDIT_RESULTS_PATH)
-            event.set_results({
-                "result": results,
-                "file": AUDIT_RESULTS_PATH
-            })
+            self.unit.status = ops.MaintenanceStatus("Executing audit...")
+            output = self.audit(xml_results_file=AUDIT_XML_RESULTS_PATH, html_results_file=AUDIT_HTML_RESULTS_PATH)
+            logger.debug(output)
+            results = {
+                'result': "Audit completed",
+                "xml-file": AUDIT_XML_RESULTS_PATH,
+                "html-file": AUDIT_HTML_RESULTS_PATH,
+            }
+            event.set_results(results)
+            logger.debug(f"Audit finished. Results {results}")
+            self.unit.status = ops.ActiveStatus(f"Audit finished. Result file: {AUDIT_HTML_RESULTS_PATH}")
         except Exception as e:
+            self.unit.status = ops.BlockedStatus("Audit failed. Check juju-debug-log")
             logger.error(f"Audit failed: {str(e)}")
 
-    def audit(self, results_file):
+    def audit(self, html_results_file, xml_results_file):
         try:
-            return subprocess.check_output(
-                f"usg audit --tailoring-file {results_file}".split(" ")
-            ).decode("utf-8")
-        except subprocess.CalledProcessError as e:
+            with tempfile.NamedTemporaryFile(mode="w", delete=False) as fh:
+                tailoring_content = base64.b64decode(
+                    self.model.config["tailoring-file"]
+                ).decode("utf-8")
+                fh.write(tailoring_content)
+                fh.flush()
+                cmd = ["usg", "audit", "--tailoring-file", fh.name, "--results-file", xml_results_file, "--html-file", html_results_file]
+                return subprocess.check_output(cmd, text=True)
+        except Exception as e:
             logger.error(f"Audit failed: {str(e)}")
             raise
 
@@ -89,12 +117,52 @@ class CharmCisHardeningCharm(ops.CharmBase):
             logger.error(f"Failed to install {USG_PACKAGE}: {str(e)}")
             raise
 
+    def is_configuration_set(self, config_key):
+        config = self.model.config
+        tailoring_file = config.get(config_key, "")
+        if not tailoring_file.strip():
+            return False
+        return True
+
+    def execute_pre_hardening_script(self):
+        """
+        Execute bash commands from pre-hardening-script config
+        Bash commands need to be run in some cases, before the hardening, in order to remediate some rules
+        """
+        if not self.is_configuration_set("pre-hardening-script"):
+            return False
+        bash_content = self.model.config.get("pre-hardening-script", "")
+        self.unit.status = ops.MaintenanceStatus("Executing pre-hardening script")
+        try:
+            # Using subprocess.run to be able to log stdout and stderr
+            result = subprocess.run(
+                bash_content, stderr=subprocess.PIPE, stdout=subprocess.PIPE,
+                shell=True, executable="/bin/bash", text=True
+            )
+
+            if result.stdout:
+                logger.info(f"Pre-hardening script output: {result.stdout}")
+            if result.stderr:
+                logger.error(f"Pre-hardening script error output: {result.stderr}")
+
+            if result.returncode == 0:
+                logger.info("Pre-hardening script executed successfully.")
+            else:
+                self.unit.status = ops.BlockedStatus(f"Pre-hardening script failed with code {result.returncode}. Check juju debug-log")
+                logger.error(f"Pre-hardening script failed with code {result.returncode}")
+                logger.error(result.stderr)
+            return result.returncode
+
+        except subprocess.SubprocessError as e:
+            logger.error(f"An error occurred while executing the pre-hardening script: {e}")
+            self.unit.status = ops.BlockedStatus("Pre-hardening script failed due to an exception. Check juju debug-log")
+            return 1
+
     def cis_harden(self):
+        tailoring_file = self.model.config.get("tailoring-file", "")
         try:
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as fh:
-                tailoring_content = base64.b64decode(
-                    self.model.config["tailoring-file"]
-                ).decode("utf-8")
+                tailoring_content = base64.b64decode(tailoring_file).decode("utf-8")
                 fh.write(tailoring_content)
                 fh.flush()
                 cmd = ["usg", "fix", "--tailoring-file", fh.name]
@@ -104,11 +172,24 @@ class CharmCisHardeningCharm(ops.CharmBase):
             raise
 
     def _cis_harden_action(self, event):
+        if not self.is_configuration_set("tailoring-file"):
+            logger.error("Tailoring-file is not set")
+            event.fail("Tailoring-file is not set")
+            self.unit.status = ops.BlockedStatus("Cannot run hardening. Please configure a tailoring-file")
+            return
+        return_code = self.execute_pre_hardening_script()
+        if return_code:
+            event.fail("Failed to run pre-hardening logs. Check juju debug-log")
+            return
+
         self.unit.status = ops.MaintenanceStatus("Executing hardening...")
         self._stored.hardening_status = False
 
         try:
             output = self.cis_harden()
+            if output:
+                event.fail("Failed to run CIS hardening. Check juju-debug-log")
+                self.unit.status = ops.BlockedStatus("Failed to run CIS hardening. Check juju-debug-log")
             filename = None
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as fh:
                 fh.write(output)
@@ -124,6 +205,7 @@ class CharmCisHardeningCharm(ops.CharmBase):
 
         except Exception as e:
             logger.error(f"Hardening action failed: {str(e)}")
+            event.fail("Hardening failed. Check juju debug-log")
             self.unit.status = ops.BlockedStatus("Hardening failed. Check juju debug-log")
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -64,7 +64,7 @@ class CharmCisHardeningCharm(ops.CharmBase):
             self.unit.status = ops.ActiveStatus("Ready for CIS hardening. Run 'execute-cis' action")
 
     def _on_start(self, event):
-        # Workaround needed https://chat.canonical.com/canonical/pl/rr9su5ceh3r98r5jbiuu6989wr
+        # Workaround needed to make sure all sysctl settings are correctly loaded
         subprocess.check_output(
             "sysctl --system".split(" ")
         ).decode("utf-8")

--- a/src/charm.py
+++ b/src/charm.py
@@ -71,7 +71,6 @@ class CharmCisHardeningCharm(ops.CharmBase):
             })
         except Exception as e:
             logger.error(f"Audit failed: {str(e)}")
-            event.fail(f"Audit failed: {str(e)}")
 
     def audit(self, results_file):
         try:
@@ -125,7 +124,6 @@ class CharmCisHardeningCharm(ops.CharmBase):
 
         except Exception as e:
             logger.error(f"Hardening action failed: {str(e)}")
-            event.fail(f"Hardening failed: {str(e)}")
             self.unit.status = ops.BlockedStatus("Hardening failed. Check juju debug-log")
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -46,7 +46,7 @@ class TestCharmCisHardening(unittest.TestCase):
 
         mock_apt_update.assert_called_once()
         mock_apt_install.assert_called_once_with(['usg'], fatal=True)
-        self.assertIsInstance(self.harness.model.unit.status, ops.BlockedStatus)
+        self.assertIsInstance(self.harness.model.unit.status, ops.ActiveStatus)
         self.assertEqual(
             self.harness.model.unit.status.message,
             "Ready for CIS hardening. Run 'execute-cis' action"
@@ -186,7 +186,7 @@ class TestCharmCisHardening(unittest.TestCase):
         self.harness.charm.on.start.emit()
 
         mock_check_output.assert_called_once_with("sysctl --system".split(" "))
-        self.assertIsInstance(self.harness.model.unit.status, ops.BlockedStatus)
+        self.assertIsInstance(self.harness.model.unit.status, ops.ActiveStatus)
         self.assertEqual(
             self.harness.model.unit.status.message,
             "Ready for CIS hardening. Run 'execute-cis' action"


### PR DESCRIPTION
- Change status from active to blocked when human intervention is required (e.g reboot)
- Add a new `storedState` with `hardening_status` to keep the hardening status (true or false). Useful after reboot to know if the unit is hardened or not yet
- Add `on_config_changed` event hook
- Add an `on_start` event to be executed after each reboot
- Update event key from `Results file` to `result`. It has to be snakecase to prevent `ValueError`
`ValueError: key 'Result' is invalid: must be similar to 'key', 'some-key2', or 'some.key'`
- Add audit XML output in addition to HTML output
- Output filename in juju status after executing hardening. Reason is: We don't know how long hardening will take and it may be longer than juju run timeout (even if customized). The output file is thus not only displayed when the action successfully ends but also displayed in juju status in case action timed out
- Add try/catch everywhere to handle errors and raise
- Add pre-hardening-script configuration: This config will execute the content of pre-hardening-script configuration (if set) as a bash script.
- Add necessary workaround `sysctl --system` upon reboot after applying hardening
- Add debug messages
- Handle case where pre-hardening-script or leading to an error
- Handle case where tailoring-file is not set
- Add unit tests with Harness: https://ops.readthedocs.io/en/latest/harness.html