### PR TITLE
Add unit tests with harness

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,68 +1,134 @@
 # Copyright 2024 pjds
 # See LICENSE file for licensing details.
-#
-# Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import unittest
+from unittest.mock import patch
+import subprocess
+import base64
 
 import ops
 import ops.testing
 from charm import CharmCisHardeningCharm
 
 
-class TestCharm(unittest.TestCase):
+DUMP_TAILORING_FILE = """<?xml version='1.0' encoding='UTF-8'?>
+<Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
+  <benchmark href="/usr/share/ubuntu-scap-security-guides/1/benchmarks/ssg-ubuntu2204-xccdf.xml"/>
+  <version time="2024-10-24T19:35:23">1</version>
+  <Profile id="xccdf_org.ssgproject.content_profile_cis_level2_server_customized" extends="xccdf_org.ssgproject.content_profile_cis_level2_server">
+    <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">CIS Ubuntu 22.04 Level 2 Server Benchmark [CUSTOMIZED]</title>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This baseline aligns to the Center for Internet Security Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.</description>
+    <!--1.1.1.1 Ensure mounting of cramfs filesystems is disabled (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_kernel_module_cramfs_disabled" selected="true"/>
+    <!--4.1.3.19 Ensure kernel module loading and unloading is collected (Automated)-->
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_modprobe" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_insmod" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_rmmod" selected="true"/>
+  </Profile>
+</Tailoring>
+"""
+
+class TestCharmCisHardening(unittest.TestCase):
     def setUp(self):
         self.harness = ops.testing.Harness(CharmCisHardeningCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.test_tailoring = base64.b64encode(bytes(DUMP_TAILORING_FILE, "UTF-8")).decode('utf-8')
 
-    def test_httpbin_pebble_ready(self):
-        # Expected plan after Pebble ready with default config
-        expected_plan = {
-            "services": {
-                "httpbin": {
-                    "override": "replace",
-                    "summary": "httpbin",
-                    "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent",
-                    "startup": "enabled",
-                    "environment": {"GUNICORN_CMD_ARGS": "--log-level info"},
-                }
-            },
-        }
-        # Simulate the container coming up and emission of pebble-ready event
-        self.harness.container_pebble_ready("httpbin")
-        # Get the plan now we've run PebbleReady
-        updated_plan = self.harness.get_container_pebble_plan("httpbin").to_dict()
-        # Check we've got the plan we expected
-        self.assertEqual(expected_plan, updated_plan)
-        # Check the service was started
-        service = self.harness.model.unit.get_container("httpbin").get_service("httpbin")
-        self.assertTrue(service.is_running())
-        # Ensure we set an ActiveStatus with no message
-        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+    def test_config_changed_valid(self):
+        """Test that a valid tailoring file is accepted."""
+        self.harness.update_config({"tailoring-file": self.test_tailoring})
+        self.assertEqual(
+            base64.b64decode(self.harness.model.config["tailoring-file"]).decode('utf-8'),
+            DUMP_TAILORING_FILE
+        )
 
-    def test_config_changed_valid_can_connect(self):
-        # Ensure the simulated Pebble API is reachable
-        self.harness.set_can_connect("httpbin", True)
-        # Trigger a config-changed event with an updated value
-        self.harness.update_config({"log-level": "debug"})
-        # Get the plan now we've run PebbleReady
-        updated_plan = self.harness.get_container_pebble_plan("httpbin").to_dict()
-        updated_env = updated_plan["services"]["httpbin"]["environment"]
-        # Check the config change was effective
-        self.assertEqual(updated_env, {"GUNICORN_CMD_ARGS": "--log-level debug"})
-        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+    def test_config_changed_invalid_base64(self):
+        with self.assertRaises(Exception):
+            # This should fail as it's not valid base64
+            self.harness.update_config({"tailoring-file": "not-base64-content"})
+            self.harness.charm.cis_harden()
 
-    def test_config_changed_valid_cannot_connect(self):
-        # Trigger a config-changed event with an updated value
-        self.harness.update_config({"log-level": "debug"})
-        # Check the charm is in WaitingStatus
-        self.assertIsInstance(self.harness.model.unit.status, ops.WaitingStatus)
-
-    def test_config_changed_invalid(self):
-        # Ensure the simulated Pebble API is reachable
-        self.harness.set_can_connect("httpbin", True)
-        # Trigger a config-changed event with an updated value
-        self.harness.update_config({"log-level": "foobar"})
-        # Check the charm is in BlockedStatus
+    @patch('charmhelpers.fetch.apt_update')
+    @patch('charmhelpers.fetch.apt_install')
+    def test_install_default(self, mock_apt_install, mock_apt_update):
+        self.harness.update_config({
+            "auto-harden": False,
+            "tailoring-file": self.test_tailoring
+        })
+        self.harness.charm.on.install.emit()
+        mock_apt_update.assert_called_once()
+        mock_apt_install.assert_called_once_with(['usg'], fatal=True)
         self.assertIsInstance(self.harness.model.unit.status, ops.BlockedStatus)
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ops.BlockedStatus("Ready for CIS hardening. Run 'execute-cis' action")
+        )
+
+    @patch('charmhelpers.fetch.apt_update')
+    @patch('charmhelpers.fetch.apt_install')
+    @patch('subprocess.check_output')
+    def test_install_with_auto_harden(self, mock_check_output, mock_apt_install, mock_apt_update):
+        self.harness.update_config({
+            "auto-harden": True,
+            "tailoring-file": self.test_tailoring
+        })
+        mock_check_output.return_value = "Hardening complete"
+        self.harness.charm.on.install.emit()
+        mock_apt_update.assert_called()
+        mock_apt_install.assert_called_with(['usg'], fatal=True)
+        mock_check_output.assert_called()
+        self.assertTrue(mock_check_output.call_args[0][0][0:2] == ['usg', 'fix'])
+
+
+    @patch('subprocess.check_output')
+    def test_execute_audit_action(self, mock_check_output):
+        """Test the execute-audit action."""
+        expected_output = "Audit results"
+        mock_check_output.return_value = expected_output.encode('utf-8')
+        action_event = self.harness.run_action("execute-audit")
+        self.harness.charm._on_audit_action(action_event)
+        mock_check_output.assert_called_with(
+            "usg audit --tailoring-file /tmp/audit.results".split(" ")
+        )
+        self.assertEqual(action_event.results["result"], expected_output)
+        self.assertEqual(action_event.results["file"], "/tmp/audit.results")
+
+    @patch('subprocess.check_output')
+    def test_start_hardened(self, mock_check_output):
+        mock_check_output.return_value = b"sysctl output"
+        self.harness.charm._stored.hardening_status = True
+        self.harness.charm.on.start.emit()
+        mock_check_output.assert_called_once_with("sysctl --system".split(" "))
+        self.assertIsInstance(self.harness.model.unit.status, ops.ActiveStatus)
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ops.ActiveStatus("Unit is hardened. Use 'execute-audit' action to check compliance")
+        )
+
+    @patch('subprocess.check_output')
+    def test_start_not_hardened(self, mock_check_output):
+        mock_check_output.return_value = b"sysctl output"
+        self.harness.charm._stored.hardening_status = False
+        self.harness.charm.on.start.emit()
+        mock_check_output.assert_called_once_with("sysctl --system".split(" "))
+        self.assertIsInstance(self.harness.model.unit.status, ops.BlockedStatus)
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ops.BlockedStatus("Ready for CIS hardening. Run 'execute-cis' action")
+        )
+
+    def test_install_failure(self):
+        with patch('charmhelpers.fetch.apt_update', side_effect=Exception("Update failed")):
+            self.harness.charm.on.install.emit()
+            self.assertIsInstance(self.harness.model.unit.status, ops.BlockedStatus)
+            self.assertEqual(
+                self.harness.model.unit.status,
+                ops.BlockedStatus("Install failed: Update failed")
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
```
tox -e unit
unit: commands[0]> coverage run --source=/home/ggouzi/Documents/DEV/Pro/charm-cis-harden/src -m pytest --tb native -v -s /home/ggouzi/Documents/DEV/Pro/charm-cis-harden/tests/unit
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0 -- /home/ggouzi/Documents/DEV/Pro/charm-cis-harden/.tox/unit/bin/python
cachedir: .tox/unit/.pytest_cache
rootdir: /home/ggouzi/Documents/DEV/Pro/charm-cis-harden
configfile: pyproject.toml
collected 8 items                                                                                                                                                                                                 

tests/unit/test_charm.py::TestCharmCisHardening::test_config_changed_invalid_base64 PASSED
tests/unit/test_charm.py::TestCharmCisHardening::test_config_changed_valid PASSED
tests/unit/test_charm.py::TestCharmCisHardening::test_execute_audit_action PASSED
tests/unit/test_charm.py::TestCharmCisHardening::test_install_default PASSED
 tests/unit/test_charm.py::TestCharmCisHardening::test_install_failure PASSED
tests/unit/test_charm.py::TestCharmCisHardening::test_install_with_auto_harden PASSED
tests/unit/test_charm.py::TestCharmCisHardening::test_start_hardened PASSED
tests/unit/test_charm.py::TestCharmCisHardening::test_start_not_hardened PASSED

================================================================================================ warnings summary =================================================================================================
tests/unit/test_charm.py::TestCharmCisHardening::test_config_changed_invalid_base64
tests/unit/test_charm.py::TestCharmCisHardening::test_config_changed_valid
tests/unit/test_charm.py::TestCharmCisHardening::test_execute_audit_action
tests/unit/test_charm.py::TestCharmCisHardening::test_install_default
tests/unit/test_charm.py::TestCharmCisHardening::test_install_failure
tests/unit/test_charm.py::TestCharmCisHardening::test_install_with_auto_harden
tests/unit/test_charm.py::TestCharmCisHardening::test_start_hardened
tests/unit/test_charm.py::TestCharmCisHardening::test_start_not_hardened
  /home/ggouzi/Documents/DEV/Pro/charm-cis-harden/tests/unit/test_charm.py:35: PendingDeprecationWarning: Harness is deprecated; we recommend using state transition testing (previously known as 'Scenario') instead
    self.harness = ops.testing.Harness(CharmCisHardeningCharm)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================== 8 passed, 8 warnings in 0.42s ==========================================================================================
unit: commands[1]> coverage report
Name           Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------
src/charm.py      82     18      6      1    78%   80-82, 107-127, 131
----------------------------------------------------------
TOTAL             82     18      6      1    78%
  unit: OK (1.02=setup[0.08]+cmd[0.82,0.12] seconds)
  congratulations :) (1.11 seconds)
```