### PR TITLE
Remove filename in juju output post-hardening

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -199,7 +199,7 @@ class CharmCisHardeningCharm(ops.CharmBase):
                 "file": filename
             })
             self.unit.status = ops.BlockedStatus(
-                f"Hardening complete. Results in {filename}. Please reboot the unit"
+                "Hardening complete. Please reboot the unit"
             )
             self._stored.hardening_status = True
 


### PR DESCRIPTION
No added value IMO and can be confusing.
We care only about the results from the audit action done after reboot.