### PR TITLE
Add get-results action to return xml/html audit result file without the need to scp

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -66,3 +66,11 @@ actions:
     description: Run audit with the tailoring file
   get-status:
     description: Get the latest status on the audit/hardening of the unit
+  get-results:
+    description: Get the audit result file content (XML or HTML)
+    params:
+      format:
+        type: string
+        default: html
+        description: |
+          format of the result file (xml or html)


### PR DESCRIPTION
results (XML/HTML files) are stored locally in /tmp.
It is fastidious to scp then using juju as we need to change their permissions and move them to another location first.

Adding the `get-results` action which takes a `format` parameter `format=xml` or `format=html` and returns the base64 encoded value of the audit file content.

Example: 
```
juju run charm-cis-hardening/leader -- get-results format=html | base64 -d > audit-resuts.html      
juju run charm-cis-hardening/leader -- get-results format=xml | base64 -d > audit-resuts.xml      
```